### PR TITLE
Use `failure` instead of `failed`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ succeeded statuses.
 statuses: |
   [
     {"name": "Build Artifact", "status": "success"},
-    {"name": "Deploy", "status": "failed"},
+    {"name": "Deploy", "status": "failure"},
     {"name": "Run Report", "status": "skipped"}
   ]
 

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ async function run() {
   let attachments = [];
   if (statuses) {
     statuses = JSON.parse(statuses);
-    const failed = statuses.filter((status) => status.status == 'failed');
+    const failed = statuses.filter((status) => status.status == 'failure');
 
     if (failed?.length) {
       attachments.push({


### PR DESCRIPTION
Github actions uses `success`, `failure`, and `skipped`.